### PR TITLE
fix(frontend/presenter): fix next line hotkey when navigator is closed

### DIFF
--- a/app/frontend/src/shared/NavigatorHotkeys.js
+++ b/app/frontend/src/shared/NavigatorHotkeys.js
@@ -72,14 +72,21 @@ const NavigatorHotKeys = ( { active, children, mouseTargetRef } ) => {
     }
   }, [ lines, lineId ] )
 
-  const goNextLine = useCallback( ( { target: { className: targetClass, parentNode } } ) => {
+  const goNextLine = useCallback( ( {
+    target: { nodeName, className: targetClass, parentNode },
+  } ) => {
     const { current: mouseTarget } = mouseTargetRef
 
     /* Near the bottom of the screen the targetClass
     becomes 'controller-container` instead of presenter.
     In this case, we check the targetClass or its parent node's class
     (which if the target is controller container, will be presenter) */
-    if ( !lines || ![ targetClass, parentNode.className ].includes( mouseTarget.className ) ) return
+    if (
+      // No lines
+      !lines
+      // Or a hotkey didn't trigger it, and another active element was clicked on
+      || ( nodeName !== 'BODY' && ![ targetClass, parentNode.className ].includes( mouseTarget.className ) )
+    ) return
 
     const currentLineIndex = findLineIndex( lines, lineId )
     const { id } = lines[ currentLineIndex ] || {}


### PR DESCRIPTION
### Summary of PR

When the navigator is closed, the down/right arrow does not navigate to the next line. This is because some checks were introduced in #451 to ensure no element has been clicked when using mouse navigator. It appears our check was too stringent, and did not account for a hotkey because the initiator of the transition.

### Tests for unexpected behavior
- ✅ Down + Right arrows advance line
- ✅ Clicking the plus sign does not advance the line
- ✅ No boundary bugs when on last line

### Time spent on PR
10 mins

### Linked issues
Fix #¯\_(ツ)_/¯#

This might be something that has been raised by @Sarabveer.

### Reviewers
@bhajneet @saihaj 