### PR TITLE
fix: correctly toggle in and out of fullscreen on hotkey in browsers

### DIFF
--- a/app/frontend/src/lib/electron-utils.js
+++ b/app/frontend/src/lib/electron-utils.js
@@ -8,4 +8,6 @@ export const toggleFullscreen = isElectron
     const window = electron().getCurrentWindow()
     window.setFullScreen( !window.isFullScreen() )
   }
-  : () => document.documentElement.requestFullscreen( document.fullscreenElement )
+  : () => ( document.fullscreenElement
+    ? document.exitFullscreen()
+    : document.documentElement.requestFullscreen( document.fullscreenElement ) )


### PR DESCRIPTION
### Summary of PR
Previously only was toggling into fullscreen but not out in web browser environments. Does not check or exit on the same keypress (ctrl-f).

### Tests for unexpected behavior
- Toggles in and out of fullscreen in web browser environments

### Time spent on PR
- 2 minutes

### Linked issues
Fix #oopsie

### Reviewers
@saihaj @bhajneet 