### PR TITLE
fix(frontend/presenter): use source abbreviation in copy citation hotkey

### DIFF
--- a/app/frontend/src/shared/CopyHotkeys.js
+++ b/app/frontend/src/shared/CopyHotkeys.js
@@ -7,7 +7,7 @@ import { SettingsContext, ContentContext, WritersContext, RecommendedSourcesCont
 import { customiseLine } from '../lib/utils'
 import { COPY_SHORTCUTS } from '../lib/keyMap'
 import { useCopyToClipboard, useCurrentLine, useTranslations, useTransliterations, useCurrentLines } from '../lib/hooks'
-import { LANGUAGES } from '../lib/consts'
+import { LANGUAGES, SOURCE_ABBREVIATIONS } from '../lib/consts'
 
 import GlobalHotKeys from './GlobalHotKeys'
 
@@ -48,10 +48,10 @@ const CopyHotkeys = ( { children } ) => {
     const { sourceId, writerId } = shabad || line.shabad
     const { sourcePage } = line
 
-    const { nameEnglish: sourceName, pageNameEnglish: pageName } = recommendedSources[ sourceId ]
+    const { pageNameEnglish: pageName } = recommendedSources[ sourceId ]
     const { nameEnglish: writerName } = writers[ writerId ]
 
-    return `${writerName} - ${sourceName} - ${pageName} ${sourcePage}`
+    return `${writerName} - ${SOURCE_ABBREVIATIONS[ sourceId ]} - ${pageName} ${sourcePage}`
   }
 
   const getAllLines = () => lines.map( ( { gurmukhi } ) => gurmukhi ).join( ' ' )


### PR DESCRIPTION
### Summary of PR
Use the source abbreviation to have BoS style when copy pasting as done for serach results in #575

### Time spent on PR
15 mins - 30 seconds for fix and rest time spent to find the line because I forgot where it was : )

### Linked issues
Fix #620 

### Reviewers
@Harjot1Singh 