### PR TITLE
feat(frontend/presenter): add options for syllabic weights and counts of gurmukhi lines

### DIFF
--- a/app/frontend/src/Presenter/Line.css
+++ b/app/frontend/src/Presenter/Line.css
@@ -82,6 +82,23 @@ p {
   line-height: 1.4;
 }
 
+.line .syllabic-weights {
+  font-size: 0.5em;
+  letter-spacing: 0.3em;
+  padding-left: 0.3em;
+}
+
+.line .syllable-count {
+  font-size: 0.5em;
+  background: var(--display-dim-background-color);
+  height: 1.5em;
+  min-width: 1.5em;
+  border-radius: 0.3em;
+  top: 0.55em;
+  position: relative;
+  margin-bottom: 0.5em;
+}
+
 .current-line .gurmukhi {
   margin-bottom: -0.12em;
 }
@@ -128,28 +145,20 @@ p {
   flex-wrap: wrap;
 }
 
-.current-line
-  .source.with-transliterations
-  .partition
-  .word {
+.current-line .word.with-rows {
   padding-bottom: 0em;
   margin-bottom: 0.4em;
 }
 
-.current-line .word.with-guides {
-  padding-right: 0.35em;
-  border-right: 0.1em double;
+.current-line .partition ~ .partition .word.with-guides,
+.current-line .word.with-guides ~ .word.with-guides {
+  padding-left: 0.35em;
+  border-left: 0.1em double;
   border-color: var(--display-dim-background-color);
 }
 
 .larivaar.current-line .word.with-guides {
   padding: 0;
-}
-
-.current-line
-  .partition:last-child
-  .word.with-guides:last-child {
-  border-right: none;
 }
 
 .word,

--- a/app/frontend/src/Presenter/Line.js
+++ b/app/frontend/src/Presenter/Line.js
@@ -123,6 +123,7 @@ const Line = ( {
                 ) )}
               </span>
             ) )}
+
             {syllableCount && ( <span className="syllable-count">{countSyllables( gurmukhi )}</span> )}
           </p>
         </CSSTransition>

--- a/app/frontend/src/Presenter/Line.js
+++ b/app/frontend/src/Presenter/Line.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { string, bool, number, objectOf, func } from 'prop-types'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import classNames from 'classnames'
+import { countSyllables, toSyllabicSymbols } from 'gurmukhi-utils'
 
 import { partitionLine, classifyWords } from '../lib/utils'
 import { DEFAULT_OPTIONS } from '../lib/options'
@@ -43,6 +44,8 @@ const Line = ( {
   gurmukhi,
   translations,
   transliterators,
+  syllabicWeights,
+  syllableCount,
   inlineTransliteration,
   inlineColumnGuides,
   spacing,
@@ -89,18 +92,20 @@ const Line = ( {
     >
       <TransitionGroup appear exit={false} component={null}>
         <CSSTransition key={gurmukhi} classNames="fade" timeout={0}>
-          <p className={classNames( 'source', { 'with-transliterations': inlineTransliteration } )}>
+          <p className="source">
             {partitionLine( gurmukhi, !vishraamCharacters ).map( ( line, lineIndex ) => (
               <span key={lineIndex} className={classNames( 'partition', partition ? 'block' : 'inline' )}>
                 {line.map( ( { word, type }, i ) => (
                   <span
                     key={`${word}-${type}-${i}`}
-                    className={classNames( type, 'word', { 'with-guides': inlineColumnGuides } )}
+                    className={classNames( type, 'word', { 'with-guides': inlineColumnGuides, 'with-rows': inlineTransliteration || syllabicWeights || inlineColumnGuides } )}
                     style={{ fontSize: `${relativeGurmukhiFontSize}em` }}
                   >
                     <span className="gurmukhi">
                       {word}
                     </span>
+
+                    {syllabicWeights && ( <span className="syllabic-weights">{toSyllabicSymbols( word )}</span> )}
 
                     {inlineTransliteration && Object
                       .entries( transliterators )
@@ -118,6 +123,7 @@ const Line = ( {
                 ) )}
               </span>
             ) )}
+            {syllableCount && ( <span className="syllable-count">{countSyllables( gurmukhi )}</span> )}
           </p>
         </CSSTransition>
 
@@ -157,6 +163,8 @@ Line.propTypes = {
   gurmukhi: string.isRequired,
   translations: objectOf( string ),
   transliterators: objectOf( func ),
+  syllabicWeights: bool,
+  syllableCount: bool,
   inlineTransliteration: bool,
   inlineColumnGuides: bool,
   spacing: string,
@@ -184,6 +192,8 @@ const {
     spacing,
     centerText,
     justifyText,
+    syllabicWeights,
+    syllableCount,
     inlineTransliteration,
     inlineColumnGuides,
     larivaarAssist,
@@ -208,6 +218,8 @@ const {
 
 Line.defaultProps = {
   className: null,
+  syllabicWeights,
+  syllableCount,
   inlineTransliteration,
   inlineColumnGuides,
   spacing,

--- a/app/frontend/src/lib/options.js
+++ b/app/frontend/src/lib/options.js
@@ -37,6 +37,8 @@ import {
   faExpandArrowsAlt,
   faRemoveFormat,
   faSearchPlus,
+  faCalculator,
+  faBalanceScale,
 } from '@fortawesome/free-solid-svg-icons'
 import {
   faKeyboard,
@@ -99,6 +101,8 @@ export const OPTIONS = {
   nextLines: { name: 'Next Lines', icon: faAlignJustify, type: OPTION_TYPES.slider, max: 5, step: 1, privacy: PRIVACY_TYPES.local },
   larivaarGurbani: { name: 'Larivaar', icon: faTextWidth, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },
   larivaarAssist: { name: 'Larivaar Assist', icon: faMarker, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },
+  syllabicWeights: { name: 'Syllabic Weights', icon: faBalanceScale, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },
+  syllableCount: { name: 'Syllable Count', icon: faCalculator, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },
   englishTranslation: { name: 'English Translation', icon: faClosedCaptioning, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },
   spanishTranslation: { name: 'Spanish Translation', icon: faClosedCaptioning, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },
   punjabiTranslation: { name: 'Punjabi Translation', icon: faClosedCaptioning, type: OPTION_TYPES.toggle, privacy: PRIVACY_TYPES.local },
@@ -221,6 +225,8 @@ export const DEFAULT_OPTIONS = {
       nextLines: 1,
       larivaarGurbani: false,
       larivaarAssist: false,
+      syllabicWeights: false,
+      syllableCount: false,
       englishTranslation: true,
       spanishTranslation: false,
       punjabiTranslation: false,


### PR DESCRIPTION
### Summary of PR
Adds options to see syllabic weight of each word or the syllable count of the entire line for presented gurmukhi

Examples:

<image src="https://user-images.githubusercontent.com/14130567/98272660-54cce380-1f5f-11eb-971c-9e1fffbb073e.png" width="600">

<image src="https://user-images.githubusercontent.com/14130567/98272763-70d08500-1f5f-11eb-98df-6e4951abf07c.png" width="600">

<image src="https://user-images.githubusercontent.com/14130567/98272786-7928c000-1f5f-11eb-8772-ca33ae2103b9.png" width="600">

### Tests for unexpected behavior
- various options juggling
- prev/next lines
- different bookmarks

### Time spent on PR
90-120 mins

### Reviewers
@Harjot1Singh 