### PR TITLE
build: rename appId to original com.shabados.desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "npm-run-all": "^4.1.5"
   },
   "build": {
-    "appId": "com.shabados.presenter",
+    "appId": "com.shabados.desktop",
     "asar": false,
     "afterSign": "./hooks/after-sign.js",
     "directories": {


### PR DESCRIPTION


### Summary of PR
Must use the same appId throughout the lifecycle of the same app, else updates and other things may break. Reverting back to original appId.
