### PR TITLE
fix: correct global + localsettings behaviour

### DIFF
--- a/app/frontend/src/Settings/DynamicOptions.js
+++ b/app/frontend/src/Settings/DynamicOptions.js
@@ -45,10 +45,17 @@ export const OptionSlot = ( { children } ) => (
 )
 OptionSlot.propTypes = { children: node.isRequired }
 
-export const ResetButton = ( { group, disabled } ) => (
+export const ResetButton = ( { group, disabled, device } ) => (
   <OptionGrid container align="center">
     <Grid item {...slotSizes.single}>
-      <Button className="reset-button" disabled={disabled} variant="contained" onClick={() => controller.resetSettingGroup( group )}>Reset to defaults</Button>
+      <Button
+        className="reset-button"
+        disabled={disabled}
+        variant="contained"
+        onClick={() => controller.resetSettingGroup( group, device )}
+      >
+        Reset to defaults
+      </Button>
     </Grid>
   </OptionGrid>
 )
@@ -56,6 +63,7 @@ export const ResetButton = ( { group, disabled } ) => (
 ResetButton.propTypes = {
   group: string.isRequired,
   disabled: bool,
+  device: string.isRequired,
 }
 
 ResetButton.defaultProps = {
@@ -113,7 +121,7 @@ const DynamicOptions = ( { device, group } ) => {
     <>
       {renderOptions()}
 
-      <ResetButton disabled={isGroupDisabled} group={group} />
+      <ResetButton disabled={isGroupDisabled} group={group} device={device} />
     </>
   )
 }

--- a/app/lib/SessionManager.js
+++ b/app/lib/SessionManager.js
@@ -315,11 +315,11 @@ class SessionManager {
    * ! This will not work for any clients that have the hostnames of `local` or `global`.
    * @param {WebSocket} client The socket client that sent the settings update.
    */
-  onSettings( client, { local = {}, global = {}, ...rest } ) {
+  async onSettings( client, { local, global, ...rest } ) {
     const { host } = client
 
     // Save global server settings
-    settingsManager.merge( global )
+    if ( global ) await settingsManager.saveSettings( global )
 
     const { settings } = this.session
 
@@ -328,7 +328,7 @@ class SessionManager {
       ...settings,
       // Only accept setting changes for public devices
       ...getPublicSettings( rest ),
-      [ host ]: local,
+      ...( local && { [ host ]: local } ),
     }
 
     this.session = { ...this.session, settings: newSettings }


### PR DESCRIPTION
### Summary of PR
The reset button for server/global settings currently do not work. This is because the sent settings always merge with the existing settings, and thus removed properties do not reset, as the existing settings are retained.

This PR modifies this behaviour to prevent automatic merging unless required. Merging always does still happen with default settings. This fixes #472.

Additionally, when global settings are updated, the server attempts to update the sender's settings with an empty object - instead, this behaviour has been replaced with a conditional update to the sender's settings, aka If a actually sender updates their settings, only then will the backend attempt to modify it.

### Tests for unexpected behavior
- Global reset settings works
- Local settings change works
- Changing global settings does not reset local settings
- Settings actually work
- Settings are persisted both on backend and frontend

### Time spent on PR
2 hours

### Linked issues
Fix #472 
Fix #449 

<!-- Thank you for your PR! If you're still working, please mark this PR as a draft. -->
<!-- If you're ready to merge, be sure to do the following: -->
<!-- 1) Add reviewer(s) -->
<!-- 2) Add assignee(s) -->
<!-- 3) Confirm PR title conforms with git commit guidelines (as we will be squashing the PR when merging) -->
