### PR TITLE
fix: call electron remote module correctly

### DIFF
--- a/app/electron/electron-wrapper.js
+++ b/app/electron/electron-wrapper.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { app } from 'electron'
 
+import * as remote from '@electron/remote/main'
 import logger from '../lib/logger'
 import { isDev } from '../lib/consts'
 import { createMainWindow, createNonMainWindows, closeNonMainWindows, createWindow, createSplashScreen, getMainWindow, getDisplayWindows } from './window'
@@ -9,6 +10,8 @@ import initMenu from './menu'
 import { version } from '../package.json'
 
 let splashScreen
+
+remote.initialize()
 
 app.on( 'ready', () => {
   logger.info( 'Starting Electron Shell' )

--- a/app/electron/window.js
+++ b/app/electron/window.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { app, BrowserWindow, screen, Menu } from 'electron'
 import { omit } from 'lodash'
+import * as remote from '@electron/remote/main'
 
 import { PORT, isDev } from '../lib/consts'
 
@@ -18,9 +19,10 @@ const fullScreenOnShow = window => window.maximize()
 export const createWindow = ( url, windowParams, onBeforeShow = () => {} ) => {
   const window = new BrowserWindow( {
     show: false,
-    webPreferences: { nodeIntegration: true },
+    webPreferences: { nodeIntegration: true, contextIsolation: false },
     ...windowParams,
   } )
+  remote.enable( window.webContents )
   window.setMenuBarVisibility( isDev )
 
   window.loadURL( url )

--- a/app/frontend/src/lib/electron-utils.js
+++ b/app/frontend/src/lib/electron-utils.js
@@ -1,7 +1,7 @@
 import { isElectron } from './consts'
 
 // eslint-disable-next-line global-require, import/no-extraneous-dependencies
-const electron = () => window.require( 'electron' ).remote
+const electron = () => window.require( '@electron/remote' )
 
 export const toggleFullscreen = isElectron
   ? () => {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shabados/backend",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@shabados/backend",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -43,6 +43,11 @@
           "dev": true
         }
       }
+    },
+    "@electron/remote": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.0.1.tgz",
+      "integrity": "sha512-bGX4/yB2bPZwXm1DsxgoABgH0Cz7oFtXJgkerB8VrStYdTyvhGAULzNLRn9rVmeAuC3VUDXaXpZIlZAZHpsLIA=="
     },
     "@hapi/bourne": {
       "version": "1.3.2",

--- a/app/package.json
+++ b/app/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/shabados/presenter#readme",
   "dependencies": {
+    "@electron/remote": "^2.0.1",
     "@sentry/node": "^5.6.2",
     "@shabados/database": "^4.7.0",
     "appdata-path": "^1.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shabados/backend",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "description": "Desktop app for presenting the Shabad OS Database on projectors, TVs, and live streams",
   "main": "electron/esm-wrapper.js",
   "scripts": {


### PR DESCRIPTION
## Summary
As per #667, the fullscreen hotkey was no longer working in Electron. This was investigated, and is actually a regression of #613, as the release notes specify that `require('electron').remote` is deprecated in favour of `require('@electron/remote')`.

This PR introduces the necessary `@electron/remote` package and adds the required initialisation commands to restore the original behaviour/functionality.


### Linked issues
Fixes #667
