### PR TITLE
fix: correct zoom imports to be relative instead of non-existent aliased

### DIFF
--- a/app/lib/zoom.js
+++ b/app/lib/zoom.js
@@ -1,6 +1,6 @@
 //! To be refactored into shared utilities
-import { LANGUAGES, TRANSLATION_ORDER, TRANSLITERATION_ORDER } from '@shabados/frontend/src/lib/data'
-import { customiseLine, getTranslations, getTransliterators } from '@shabados/frontend/src/lib/line'
+import { LANGUAGES, TRANSLATION_ORDER, TRANSLITERATION_ORDER } from '../frontend/src/lib/data'
+import { customiseLine, getTranslations, getTransliterators } from '../frontend/src/lib/line'
 import { stripVishraams, toUnicode } from 'gurmukhi-utils'
 import { mapValues } from 'lodash'
 import Url from 'url-parse'


### PR DESCRIPTION
Zoom.js imports were trying to access non-existent aliased imports. They've been changed to relative imports now.

Without this change, the app was unrunnable because the imports were not resolvable.