### PR TITLE
Make settings background colour fill the screen regardless of content length

### DIFF
--- a/app/frontend/src/Settings/index.css
+++ b/app/frontend/src/Settings/index.css
@@ -53,12 +53,11 @@
 
 .settings main {
   display: flex;
-  min-height: fit-content;
   flex-direction: column;
+  flex-grow: 1;
   padding: 25px;
   background-color: var(--settings-background-color);
   color: var(--settings-text-color);
-  height: 100%;
   transition: 0.3s all;
 }
 


### PR DESCRIPTION
As described by #655, if the settings content was beyond 100% of the viewport height, the main element doesn't actually follow along and stretch to hold the full content.

This PR makes the settings background colour fill the screen regardless of the content length.

Flex-grow is used to make the main element always stretch to at least the size of the viewport. If the content is longer than the viewport size, it will keep stretching to fit all of the content. This means the background colour will always be visible.