### PR TITLE
Upgrade to React Router v6 functions

### DIFF
--- a/apps/frontend/src/Controller/Navigator.js
+++ b/apps/frontend/src/Controller/Navigator.js
@@ -18,7 +18,7 @@ import { stripVishraams } from 'gurmukhi-utils'
 import { invert } from 'lodash'
 import { bool, func, string } from 'prop-types'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
-import { Redirect, useLocation } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 
 import { getJumpLines, getNextJumpLine } from '../lib/auto-jump'
 import { SEARCH_URL } from '../lib/consts'
@@ -135,7 +135,7 @@ const Navigator = ( { updateFocus, register, focused } ) => {
   } ), {} ), [] )
 
   // If there's no Shabad to show, go back to the controller
-  if ( !lines.length ) return <Redirect to={{ ...location, pathname: SEARCH_URL }} />
+  if ( !lines.length ) return <Navigate to={{ ...location, pathname: SEARCH_URL }} />
 
   const jumpLines = invert( getJumpLines( content ) )
   const nextLineId = getNextJumpLine( content )

--- a/apps/frontend/src/Controller/Navigator.js
+++ b/apps/frontend/src/Controller/Navigator.js
@@ -135,7 +135,7 @@ const Navigator = ( { updateFocus, register, focused } ) => {
   } ), {} ), [] )
 
   // If there's no Shabad to show, go back to the controller
-  if ( !lines.length ) return <Navigate to={{ ...location, pathname: SEARCH_URL }} />
+  if ( !lines.length ) return <Navigate to={{ ...location, pathname: SEARCH_URL }} replace />
 
   const jumpLines = invert( getJumpLines( content ) )
   const nextLineId = getNextJumpLine( content )

--- a/apps/frontend/src/Controller/Search/index.js
+++ b/apps/frontend/src/Controller/Search/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames'
 import { func, number, oneOfType, string } from 'prop-types'
 import { stringify } from 'querystring'
 import { useCallback, useContext, useEffect, useRef, useState } from 'react'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import {
   MIN_SEARCH_CHARS,
@@ -56,7 +56,7 @@ const Search = ( { updateFocus, register, focused } ) => {
   } = {} } = useContext( SettingsContext )
 
   // Set the initial search query from URL
-  const history = useHistory()
+  const navigate = useNavigate()
   const { search } = useLocation()
   const { query = '' } = getUrlState( search )
 
@@ -106,12 +106,12 @@ const Search = ( { updateFocus, register, focused } ) => {
     setAnchor( anchor )
 
     // Update URL with search
-    history.push( { search: `?${stringify( {
+    navigate( { search: `?${stringify( {
       ...getUrlState( search ),
       query: value,
     } )}` } )
   }, [
-    history,
+    navigate,
     search,
     resultTranslationLanguage,
     resultTransliterationLanguage,
@@ -166,15 +166,15 @@ const Search = ( { updateFocus, register, focused } ) => {
         disableUnderline
         autoFocus
         endAdornment={inputValue.current && (
-        <InputAdornment>
-          <IconButton
-            className="clear"
-            onClick={() => onChange( { target: { value: '' } } )}
-            size="large"
-          >
-            <FontAwesomeIcon icon={faTimes} />
-          </IconButton>
-        </InputAdornment>
+          <InputAdornment>
+            <IconButton
+              className="clear"
+              onClick={() => onChange( { target: { value: '' } } )}
+              size="large"
+            >
+              <FontAwesomeIcon icon={faTimes} />
+            </IconButton>
+          </InputAdornment>
         )}
         inputProps={{
           spellCheck: false,

--- a/apps/frontend/src/Controller/index.tsx
+++ b/apps/frontend/src/Controller/index.tsx
@@ -17,7 +17,7 @@ import classNames from 'classnames'
 import { func, string } from 'prop-types'
 import queryString from 'qs'
 import { useContext, useEffect, useState } from 'react'
-import { Redirect, Route, Routes, useHistory, useLocation } from 'react-router-dom'
+import { Redirect, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 
 import {
   BOOKMARKS_URL,
@@ -49,7 +49,7 @@ const TopBar = ( { title, onHover } ) => {
 
   const location = useLocation()
   const { search, pathname } = location
-  const history = useHistory()
+  const navigate = useNavigate()
 
   const state = getUrlState( search )
 
@@ -66,7 +66,7 @@ const TopBar = ( { title, onHover } ) => {
       <ToolbarButton
         name="Minimize"
         icon={faWindowMinimize}
-        onClick={() => history.push( PRESENTER_URL )}
+        onClick={() => navigate( PRESENTER_URL )}
         onMouseEnter={() => onHover( 'Hide Controller' )}
         onMouseLeave={resetHover}
       />
@@ -75,7 +75,7 @@ const TopBar = ( { title, onHover } ) => {
           name="Minimize Controller"
           icon={faWindowMaximize}
           flip="vertical"
-          onClick={() => history.push( {
+          onClick={() => navigate( {
             ...location,
             search: queryString.stringify( { ...state, [ STATES.controllerOnly ]: undefined } ),
           } )}
@@ -86,7 +86,7 @@ const TopBar = ( { title, onHover } ) => {
         <ToolbarButton
           name="Maximize Controller"
           icon={faWindowMaximize}
-          onClick={() => history.push( {
+          onClick={() => navigate( {
             ...location,
             search: queryString.stringify( { ...state, [ STATES.controllerOnly ]: true } ),
           } )}
@@ -100,7 +100,7 @@ const TopBar = ( { title, onHover } ) => {
           const popOutQuery = queryString.stringify( { ...state, [ STATES.controllerOnly ]: true } )
 
           controller.openWindow( `${pathname}?${popOutQuery}`, { alwaysOnTop: true } )
-          history.push( PRESENTER_URL )
+          navigate( PRESENTER_URL )
         }}
         onMouseEnter={() => onHover( 'Pop Out Controller' )}
         onMouseLeave={resetHover}
@@ -127,12 +127,12 @@ TopBar.defaultProps = {
  * @param onHover Fired on hover with name.
  */
 const BottomBar = ( { renderContent, onHover } ) => {
-  const history = useHistory()
+  const navigate = useNavigate()
   const location = useLocation()
 
   const lines = useCurrentLines()
 
-  const go = ( pathname: string ) => () => history.push( { ...location, pathname } )
+  const go = ( pathname: string ) => () => navigate( { ...location, pathname } )
   const resetHover = () => onHover( null )
 
   return (
@@ -154,13 +154,13 @@ const BottomBar = ( { renderContent, onHover } ) => {
       />
       <div className="middle">{renderContent()}</div>
       {!!lines.length && (
-      <ToolbarButton
-        name="Navigator"
-        icon={faMap}
-        onClick={go( NAVIGATOR_URL )}
-        onMouseEnter={() => onHover( 'Navigator' )}
-        onMouseLeave={resetHover}
-      />
+        <ToolbarButton
+          name="Navigator"
+          icon={faMap}
+          onClick={go( NAVIGATOR_URL )}
+          onMouseEnter={() => onHover( 'Navigator' )}
+          onMouseLeave={resetHover}
+        />
       )}
       <ToolbarButton
         name="Clear"
@@ -197,7 +197,7 @@ const Controller = ( props ) => {
   const location = useLocation()
   const { search } = location
 
-  const history = useHistory()
+  const navigate = useNavigate()
 
   const [ lastUrl, setLastUrl ] = useState( `${NAVIGATOR_URL}${search}` )
 
@@ -214,7 +214,7 @@ const Controller = ( props ) => {
     const isTransition = lines.length && lines !== previousLines
 
     if ( isTransition && redirects.some( ( route ) => pathname.includes( route ) ) ) {
-      history.push( { ...location, pathname: NAVIGATOR_URL } )
+      navigate( { ...location, pathname: NAVIGATOR_URL } )
     }
   }, [ history, lines, previousLines, location ] )
 
@@ -249,10 +249,10 @@ const Controller = ( props ) => {
                 {...props}
                 onHover={setHovered}
                 renderContent={() => BarComponent && (
-                <BarComponent
-                  {...props}
-                  onHover={setHovered}
-                />
+                  <BarComponent
+                    {...props}
+                    onHover={setHovered}
+                  />
                 )}
               />
             </div>

--- a/apps/frontend/src/Controller/index.tsx
+++ b/apps/frontend/src/Controller/index.tsx
@@ -17,7 +17,7 @@ import classNames from 'classnames'
 import { func, string } from 'prop-types'
 import queryString from 'qs'
 import { useContext, useEffect, useState } from 'react'
-import { Redirect, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
+import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 
 import {
   BOOKMARKS_URL,
@@ -260,7 +260,7 @@ const Controller = ( props ) => {
         />
       ) )}
 
-      <Route element={<Redirect to={lastUrl} />} />
+      <Route element={<Navigate to={lastUrl} replace />} />
     </Routes>
   )
 }

--- a/apps/frontend/src/Presenter/index.js
+++ b/apps/frontend/src/Presenter/index.js
@@ -8,7 +8,7 @@ import classNames from 'classnames'
 import queryString from 'qs'
 import { lazy, Suspense, useContext, useRef, useState } from 'react'
 import IdleTimer from 'react-idle-timer'
-import { Route, useHistory, useLocation } from 'react-router-dom'
+import { Route, useLocation, useNavigate } from 'react-router-dom'
 
 import {
   BOOKMARKS_URL,
@@ -53,7 +53,7 @@ const DEFAULT_IDLE_EVENTS = [
 ]
 
 const Presenter = () => {
-  const history = useHistory()
+  const navigate = useNavigate()
   const location = useLocation()
   const { search, pathname } = location
   const { controllerOnly } = getUrlState( search )
@@ -78,7 +78,7 @@ const Presenter = () => {
    * Sets the query string parameters, retaining any currently present.
    * @param params The query string parameters.
    */
-  const setQueryParams = ( params ) => history.push( {
+  const setQueryParams = ( params ) => navigate( {
     ...location,
     search: queryString.stringify( { ...getUrlState( search ), ...params } ),
   } )
@@ -87,7 +87,7 @@ const Presenter = () => {
    * More concise form to navigate to URLs, retaining query params.
    * @param pathname The path to navigate to.
    */
-  const go = ( pathname ) => history.push( { ...location, pathname } )
+  const go = ( pathname ) => navigate( { ...location, pathname } )
 
   /**
    * Toggles the controller.
@@ -100,7 +100,7 @@ const Presenter = () => {
   /**
    * Always puts the controller in fullscreen.
    */
-  const setFullscreenController = () => history.push( {
+  const setFullscreenController = () => navigate( {
     pathname: CONTROLLER_URL,
     search: queryString.stringify( { [ STATES.controllerOnly ]: true } ),
   } )

--- a/apps/frontend/src/Settings/index.js
+++ b/apps/frontend/src/Settings/index.js
@@ -181,7 +181,7 @@ const Settings = () => {
 
       <main onClick={closeMobileMenu}>
         <Routes>
-          <Route path={SETTINGS_DEVICE_URL} render={() => <Navigate to={defaultUrl} />} />
+          <Route path={SETTINGS_DEVICE_URL} render={() => <Navigate to={defaultUrl} replace />} />
 
           {/* Device setting routes */}
           <Route
@@ -203,7 +203,7 @@ const Settings = () => {
           <Route path={`${SETTINGS_TOOLS_URL}/closedCaptions`} component={ClosedCaptionSettings} />
           <Route path={`${SETTINGS_TOOLS_URL}/*`} render={() => <DynamicOptions device="global" group={group} />} />
 
-          <Route render={() => <Navigate to={defaultUrl} />} />
+          <Route render={() => <Navigate to={defaultUrl} replace />} />
         </Routes>
       </main>
     </div>

--- a/apps/frontend/src/Settings/index.js
+++ b/apps/frontend/src/Settings/index.js
@@ -24,7 +24,7 @@ import {
 import classNames from 'classnames'
 import { bool, func, shape, string } from 'prop-types'
 import { useContext, useEffect, useState } from 'react'
-import { Link, Redirect, Route, Routes, useLocation } from 'react-router-dom'
+import { Link, Navigate, Route, Routes, useLocation } from 'react-router-dom'
 
 import {
   BACKEND_URL,
@@ -181,7 +181,7 @@ const Settings = () => {
 
       <main onClick={closeMobileMenu}>
         <Routes>
-          <Route path={SETTINGS_DEVICE_URL} render={() => <Redirect to={defaultUrl} />} />
+          <Route path={SETTINGS_DEVICE_URL} render={() => <Navigate to={defaultUrl} />} />
 
           {/* Device setting routes */}
           <Route
@@ -203,7 +203,7 @@ const Settings = () => {
           <Route path={`${SETTINGS_TOOLS_URL}/closedCaptions`} component={ClosedCaptionSettings} />
           <Route path={`${SETTINGS_TOOLS_URL}/*`} render={() => <DynamicOptions device="global" group={group} />} />
 
-          <Route render={() => <Redirect to={defaultUrl} />} />
+          <Route render={() => <Navigate to={defaultUrl} />} />
         </Routes>
       </main>
     </div>


### PR DESCRIPTION
React Router DOM package is changing things like `useHistory()` in v5 to `useNavigate()` in v6. See [here](https://reactrouter.com/en/main/upgrading/v5) for more details.
The app currently uses the old `useHistory()` hook from the React Router package, but the app has v6 installed, so we'd like to update usages of the old function wherever possible.
We also want to replace `<Redirect />` with `<Navigate />`.

This PR:
* Replaces `useHistory()` usages with `useNavigate()`, the new function for v6 of the router package.
* Replaces `<Redirect />` with `<Navigate />`.

Implements #678.